### PR TITLE
Create custom editor

### DIFF
--- a/Modular Weapon System/Assets/Demo/Prefabs/BouncyRifle.prefab
+++ b/Modular Weapon System/Assets/Demo/Prefabs/BouncyRifle.prefab
@@ -175,7 +175,6 @@ GameObject:
   - component: {fileID: 4912248076444906449}
   - component: {fileID: 1113645940305911508}
   - component: {fileID: 5048943717684086433}
-  - component: {fileID: 6846973093513416095}
   m_Layer: 10
   m_Name: BouncyRifle
   m_TagString: Untagged
@@ -242,7 +241,7 @@ MonoBehaviour:
   gunData: {fileID: 11400000, guid: b786e0764513c6244a915247ddd8fbaf, type: 2}
   fireComponent: {fileID: 1113645940305911508}
   reloadComponent: {fileID: 5048943717684086433}
-  abilityComponent: {fileID: 6846973093513416095}
+  ability: {fileID: 11400000, guid: a4fe217e4365bfc45a3ffad82fbbcaea, type: 2}
   gunMuzzlePosition: {fileID: 6178587534755681426}
   bulletsInMagazine: 30
 --- !u!114 &1113645940305911508
@@ -272,19 +271,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   componentAudio: {fileID: 8300000, guid: 22d9dd7aebf329d4b8d893dddc0789be, type: 3}
   reloadAnimClip: {fileID: 7400000, guid: d5294b4d207d4fb43abb667226a4c268, type: 2}
---- !u!114 &6846973093513416095
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1495833626750918590}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8f2b2872f1842c845b414679392cb43a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  componentAudio: {fileID: 0}
 --- !u!1 &3299091718481543507
 GameObject:
   m_ObjectHideFlags: 0

--- a/Modular Weapon System/Assets/Demo/Prefabs/Heavy.prefab
+++ b/Modular Weapon System/Assets/Demo/Prefabs/Heavy.prefab
@@ -13,7 +13,6 @@ GameObject:
   - component: {fileID: 4297096793453073403}
   - component: {fileID: 8175349965140831203}
   - component: {fileID: 6045425038984235462}
-  - component: {fileID: 5412026989104105833}
   m_Layer: 10
   m_Name: Heavy
   m_TagString: Untagged
@@ -79,7 +78,7 @@ MonoBehaviour:
   gunData: {fileID: 11400000, guid: f4c3310d82e62554987099514bc5c59c, type: 2}
   fireComponent: {fileID: 8175349965140831203}
   reloadComponent: {fileID: 6045425038984235462}
-  abilityComponent: {fileID: 5412026989104105833}
+  ability: {fileID: 11400000, guid: a4fe217e4365bfc45a3ffad82fbbcaea, type: 2}
   gunMuzzlePosition: {fileID: 2927981984626177026}
   bulletsInMagazine: 100
 --- !u!114 &8175349965140831203
@@ -109,19 +108,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   componentAudio: {fileID: 8300000, guid: 22d9dd7aebf329d4b8d893dddc0789be, type: 3}
   reloadAnimClip: {fileID: 7400000, guid: 3aadce550d0006342985befc4f6aeea7, type: 2}
---- !u!114 &5412026989104105833
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 62048590246468424}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8f2b2872f1842c845b414679392cb43a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  componentAudio: {fileID: 0}
 --- !u!1 &1248052739257870694
 GameObject:
   m_ObjectHideFlags: 0

--- a/Modular Weapon System/Assets/Demo/Prefabs/HitscanPistol.prefab
+++ b/Modular Weapon System/Assets/Demo/Prefabs/HitscanPistol.prefab
@@ -256,7 +256,6 @@ GameObject:
   - component: {fileID: 2531185856949675137}
   - component: {fileID: 3542828430770028827}
   - component: {fileID: 4833989857084666534}
-  - component: {fileID: 8432678299826597404}
   m_Layer: 10
   m_Name: HitscanPistol
   m_TagString: Untagged
@@ -323,7 +322,7 @@ MonoBehaviour:
   gunData: {fileID: 11400000, guid: 9f28dc94d3f4b284d9059cab08c8c723, type: 2}
   fireComponent: {fileID: 3542828430770028827}
   reloadComponent: {fileID: 4833989857084666534}
-  abilityComponent: {fileID: 8432678299826597404}
+  ability: {fileID: 11400000, guid: a4fe217e4365bfc45a3ffad82fbbcaea, type: 2}
   gunMuzzlePosition: {fileID: 7328972505774998201}
   bulletsInMagazine: 15
 --- !u!114 &3542828430770028827
@@ -353,19 +352,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   componentAudio: {fileID: 8300000, guid: 22d9dd7aebf329d4b8d893dddc0789be, type: 3}
   reloadAnimClip: {fileID: 7400000, guid: 0294ff2cfed2bb246b6d2722ac89d331, type: 2}
---- !u!114 &8432678299826597404
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4522165148204137533}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8f2b2872f1842c845b414679392cb43a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  componentAudio: {fileID: 0}
 --- !u!1 &4632755768500378388
 GameObject:
   m_ObjectHideFlags: 0

--- a/Modular Weapon System/Assets/Demo/Prefabs/Pistol.prefab
+++ b/Modular Weapon System/Assets/Demo/Prefabs/Pistol.prefab
@@ -13,7 +13,6 @@ GameObject:
   - component: {fileID: 3222707270696849898}
   - component: {fileID: 1573575704403255662}
   - component: {fileID: 9134265160153052053}
-  - component: {fileID: 6654439762706728387}
   m_Layer: 10
   m_Name: Pistol
   m_TagString: Untagged
@@ -80,7 +79,7 @@ MonoBehaviour:
   gunData: {fileID: 11400000, guid: b364378b20065a44ba86bbaedaec2996, type: 2}
   fireComponent: {fileID: 1573575704403255662}
   reloadComponent: {fileID: 9134265160153052053}
-  abilityComponent: {fileID: 6654439762706728387}
+  ability: {fileID: 11400000, guid: a4fe217e4365bfc45a3ffad82fbbcaea, type: 2}
   gunMuzzlePosition: {fileID: 5542251227284466022}
   bulletsInMagazine: 15
 --- !u!114 &1573575704403255662
@@ -110,19 +109,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   componentAudio: {fileID: 8300000, guid: 22d9dd7aebf329d4b8d893dddc0789be, type: 3}
   reloadAnimClip: {fileID: 7400000, guid: 0294ff2cfed2bb246b6d2722ac89d331, type: 2}
---- !u!114 &6654439762706728387
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1701868865917179874}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8f2b2872f1842c845b414679392cb43a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  componentAudio: {fileID: 0}
 --- !u!1 &2279727261924345019
 GameObject:
   m_ObjectHideFlags: 0

--- a/Modular Weapon System/Assets/Demo/Prefabs/Rifle.prefab
+++ b/Modular Weapon System/Assets/Demo/Prefabs/Rifle.prefab
@@ -529,7 +529,6 @@ GameObject:
   - component: {fileID: 4201866381835939764}
   - component: {fileID: 8333513288239099935}
   - component: {fileID: 8516015598485923695}
-  - component: {fileID: 1621676690077608298}
   m_Layer: 10
   m_Name: Rifle
   m_TagString: Untagged
@@ -596,7 +595,7 @@ MonoBehaviour:
   gunData: {fileID: 11400000, guid: e22c08866b4be7140b26e0826fdcd402, type: 2}
   fireComponent: {fileID: 8333513288239099935}
   reloadComponent: {fileID: 8516015598485923695}
-  abilityComponent: {fileID: 1621676690077608298}
+  ability: {fileID: 11400000, guid: a4fe217e4365bfc45a3ffad82fbbcaea, type: 2}
   gunMuzzlePosition: {fileID: 2034166035830665319}
   bulletsInMagazine: 30
 --- !u!114 &8333513288239099935
@@ -626,19 +625,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   componentAudio: {fileID: 8300000, guid: 22d9dd7aebf329d4b8d893dddc0789be, type: 3}
   reloadAnimClip: {fileID: 7400000, guid: d5294b4d207d4fb43abb667226a4c268, type: 2}
---- !u!114 &1621676690077608298
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6721142343288732491}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8f2b2872f1842c845b414679392cb43a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  componentAudio: {fileID: 0}
 --- !u!1 &7227351525974844838
 GameObject:
   m_ObjectHideFlags: 0

--- a/Modular Weapon System/Assets/Demo/Prefabs/Sniper.prefab
+++ b/Modular Weapon System/Assets/Demo/Prefabs/Sniper.prefab
@@ -256,7 +256,6 @@ GameObject:
   - component: {fileID: 8546975765903760623}
   - component: {fileID: 5896903725068885182}
   - component: {fileID: 5677957116567223672}
-  - component: {fileID: 8593350361980819877}
   m_Layer: 10
   m_Name: Sniper
   m_TagString: Untagged
@@ -326,7 +325,7 @@ MonoBehaviour:
   gunData: {fileID: 11400000, guid: 40cd74cf9bb51d54997d635f98a1ed7b, type: 2}
   fireComponent: {fileID: 5896903725068885182}
   reloadComponent: {fileID: 5677957116567223672}
-  abilityComponent: {fileID: 8593350361980819877}
+  ability: {fileID: 11400000, guid: a4fe217e4365bfc45a3ffad82fbbcaea, type: 2}
   gunMuzzlePosition: {fileID: 3801107514549961429}
   bulletsInMagazine: 5
 --- !u!114 &5896903725068885182
@@ -356,19 +355,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   componentAudio: {fileID: 8300000, guid: 22d9dd7aebf329d4b8d893dddc0789be, type: 3}
   reloadAnimClip: {fileID: 7400000, guid: 49a7f273bd98b184d82547c5f703d31e, type: 2}
---- !u!114 &8593350361980819877
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3630896513282049607}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8f2b2872f1842c845b414679392cb43a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  componentAudio: {fileID: 0}
 --- !u!1 &3801107514549961429
 GameObject:
   m_ObjectHideFlags: 0

--- a/Modular Weapon System/Assets/Demo/Scenes/DemoScene.unity
+++ b/Modular Weapon System/Assets/Demo/Scenes/DemoScene.unity
@@ -239,6 +239,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8546975765903760623, guid: 63f77325e1eab2f4fb6205968f57397a, type: 3}
+      propertyPath: abilityComponent
+      value: 
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 63f77325e1eab2f4fb6205968f57397a, type: 3}
 --- !u!1 &537717816
@@ -527,6 +531,10 @@ PrefabInstance:
     - target: {fileID: 1701868865917179874, guid: 7a83bfc30e3333a4fb98c1861d9f4a49, type: 3}
       propertyPath: m_Name
       value: Pistol
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222707270696849898, guid: 7a83bfc30e3333a4fb98c1861d9f4a49, type: 3}
+      propertyPath: abilityComponent
+      value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7a83bfc30e3333a4fb98c1861d9f4a49, type: 3}
@@ -871,6 +879,10 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 15
       objectReference: {fileID: 0}
+    - target: {fileID: 4297096793453073403, guid: 7a1de40a808a75744a0b97c0bd866e96, type: 3}
+      propertyPath: abilityComponent
+      value: 
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7a1de40a808a75744a0b97c0bd866e96, type: 3}
 --- !u!1 &1667768243
@@ -1047,6 +1059,10 @@ PrefabInstance:
       propertyPath: masksToIgnore.m_Bits
       value: 1536
       objectReference: {fileID: 0}
+    - target: {fileID: 4912248076444906449, guid: 29b41ac60eed1934a966394aac21ef36, type: 3}
+      propertyPath: abilityComponent
+      value: 
+      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 1300875942242333761, guid: 29b41ac60eed1934a966394aac21ef36, type: 3}
     - {fileID: 103013511177375922, guid: 29b41ac60eed1934a966394aac21ef36, type: 3}
@@ -1059,6 +1075,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 4201866381835939764, guid: a68b874a02e27b44aa85fd44fe9a98d3, type: 3}
+      propertyPath: abilityComponent
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 6388990592327188648, guid: a68b874a02e27b44aa85fd44fe9a98d3, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -1136,6 +1156,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 2531185856949675137, guid: 0ecb8b8c36c41e44cad60a243d304102, type: 3}
+      propertyPath: abilityComponent
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 4264345279264573406, guid: 0ecb8b8c36c41e44cad60a243d304102, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -1252,6 +1276,10 @@ PrefabInstance:
     - target: {fileID: 1495833626750918590, guid: 29b41ac60eed1934a966394aac21ef36, type: 3}
       propertyPath: m_Name
       value: BouncyRifle
+      objectReference: {fileID: 0}
+    - target: {fileID: 4912248076444906449, guid: 29b41ac60eed1934a966394aac21ef36, type: 3}
+      propertyPath: abilityComponent
+      value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 29b41ac60eed1934a966394aac21ef36, type: 3}

--- a/Modular Weapon System/Assets/Demo/Scripts/Default/Gun/Blank Gun Ability.asset
+++ b/Modular Weapon System/Assets/Demo/Scripts/Default/Gun/Blank Gun Ability.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d7e4579aea10384a85c69b3c31fe114, type: 3}
+  m_Name: Blank Gun Ability
+  m_EditorClassIdentifier: 

--- a/Modular Weapon System/Assets/Demo/Scripts/Default/Gun/Blank Gun Ability.asset.meta
+++ b/Modular Weapon System/Assets/Demo/Scripts/Default/Gun/Blank Gun Ability.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a4fe217e4365bfc45a3ffad82fbbcaea
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Modular Weapon System/Assets/Demo/Scripts/Default/Gun/DefaultGunAbilityComponent.cs
+++ b/Modular Weapon System/Assets/Demo/Scripts/Default/Gun/DefaultGunAbilityComponent.cs
@@ -1,8 +1,0 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
-public class DefaultGunAbilityComponent : GunAbilityComponent
-{
-
-}

--- a/Modular Weapon System/Assets/Prefabs/Gun Mods.meta
+++ b/Modular Weapon System/Assets/Prefabs/Gun Mods.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 604029c5093a6004d80277786324a0c4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Modular Weapon System/Assets/Prefabs/Guns.meta
+++ b/Modular Weapon System/Assets/Prefabs/Guns.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1e4fd81b36351d747904c512372d0795
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Modular Weapon System/Assets/Prefabs/Projectiles.meta
+++ b/Modular Weapon System/Assets/Prefabs/Projectiles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5361e829be082c042a40de050c96fb09
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Modular Weapon System/Assets/Scripts/Editor.meta
+++ b/Modular Weapon System/Assets/Scripts/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e05e7a8cb42c7c343a584b0d19f044c8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Modular Weapon System/Assets/Scripts/Editor/GunCreationTool.cs
+++ b/Modular Weapon System/Assets/Scripts/Editor/GunCreationTool.cs
@@ -1,0 +1,303 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+public class GunCreationTool : EditorWindow
+{
+    Vector2 scrollPosition = Vector2.zero;
+
+    [Header("Gun Settings")] 
+    readonly string gunPrefabPath = "Assets/Prefabs/Guns/";
+    string gunName;
+    GameObject selectedGunModel;
+    Material selectedGunMaterial;
+    GunData selectedGunData;
+    bool useExistingGunData, hasAbility, isHitscan;
+    GunAbility selectedAbility;
+    bool CanCreateNewGun => !String.IsNullOrEmpty(gunName) && selectedGunModel != null;
+
+    [Header("Gun Data Settings")] 
+    FireMode fireMode;
+    AmmoCategory ammoCategory;
+    int damage;
+    int magazineSize;
+    int roundsPerMinute;
+    int baseCritChance;
+    float baseCritMultiplier;
+    int baseStunChance;
+
+    GameObject createdGun;
+
+    [Header("Projectile Settings")] 
+    readonly string projectilePrefabPath = "Assets/Prefabs/Projectiles/";
+    string projectileName;
+    GameObject selectedExistingProjectile;
+    GameObject selectedProjectileModel;
+    Material selectedProjectileMaterial;
+    float projectileSpeed, maxProjectileTravel;
+    bool useExistingProjectile, isSticky, isBouncy;
+    bool CanUseExistingProjectile => useExistingProjectile && selectedExistingProjectile != null;
+    bool CanCreateNewProjectile => !String.IsNullOrEmpty(projectileName) && selectedProjectileModel != null;
+
+    GameObject createdProjectile;
+
+    [Header("Gun and Projectile Previews")]
+    Editor gunPreviewEditor;
+
+    Editor projectilePreviewEditor;
+
+    [MenuItem("Tools/Gun Creation Tool")]
+    public static void OpenWindow() => GetWindow<GunCreationTool>("Gun Creator");
+
+    void OnGUI(){
+        scrollPosition = EditorGUILayout.BeginScrollView(scrollPosition);
+
+        GUILayout.BeginHorizontal();
+        SetupArea();
+        PreviewArea();
+        GUILayout.EndHorizontal();
+
+        EditorGUILayout.EndScrollView();
+
+    }
+
+    void SetupArea(){
+        GUILayout.BeginVertical();
+
+        EditorGUILayout.LabelField("Gun Setup", EditorStyles.boldLabel);
+        GunSetup();
+        BuildGunAndProjectile();
+
+        GUILayout.EndVertical();
+    }
+
+    #region Model preview area methods
+
+    void PreviewArea(){
+        GUILayout.BeginVertical();
+
+        GunPreview();
+        ProjectilePreview();
+
+        GUILayout.EndVertical();
+    }
+
+    void GunPreview(){
+        if (gunPreviewEditor == null){
+            gunPreviewEditor = Editor.CreateEditor(selectedGunModel);
+        }
+
+        if (selectedGunModel == null) return;
+
+        if (gunPreviewEditor.target != selectedGunModel){
+            gunPreviewEditor = Editor.CreateEditor(selectedGunModel);
+        }
+
+        gunPreviewEditor.OnPreviewGUI(GUILayoutUtility.GetRect(Screen.width / 2, Screen.height),
+            EditorStyles.whiteLabel);
+    }
+
+    void ProjectilePreview(){
+        if (projectilePreviewEditor == null){
+            projectilePreviewEditor = Editor.CreateEditor(selectedProjectileModel);
+        }
+
+        if (selectedProjectileModel == null) return;
+
+        if (projectilePreviewEditor.target != selectedProjectileModel){
+            projectilePreviewEditor = Editor.CreateEditor(selectedProjectileModel);
+        }
+
+        projectilePreviewEditor.OnPreviewGUI(GUILayoutUtility.GetRect(Screen.width / 2, Screen.height),
+            EditorStyles.whiteLabel);
+    }
+
+    #endregion
+
+    #region Gun setup methods
+
+    void GunSetup(){
+        EditorGUILayout.LabelField("Unique Gun Name:");
+        gunName = EditorGUILayout.TextField(gunName);
+
+        EditorGUILayout.LabelField("Gun Model:");
+        selectedGunModel = (GameObject) EditorGUILayout.ObjectField(selectedGunModel, typeof(GameObject), false);
+
+        EditorGUILayout.LabelField("Gun Material:");
+        selectedGunMaterial = (Material) EditorGUILayout.ObjectField(selectedGunMaterial, typeof(Material), false);
+
+        isHitscan = EditorGUILayout.Toggle("Hitscan?", isHitscan);
+
+        if (hasAbility = EditorGUILayout.Toggle("Has Gun Ability?", hasAbility)){
+            EditorGUILayout.LabelField("Ability:");
+            selectedAbility = EditorGUILayout.ObjectField(selectedAbility, typeof(GunAbility), false) as GunAbility;
+        }
+        else{
+            selectedAbility = null;
+        }
+
+        if (useExistingGunData = EditorGUILayout.Toggle("Use Existing Gun Data?", useExistingGunData)){
+            SelectExistingGunData();
+        }
+        else{
+            SetNewGunData();
+            
+            if (useExistingProjectile = EditorGUILayout.Toggle("Use Existing Projectile?", useExistingProjectile)){
+                SelectExistingProjectile();
+            }
+            else{
+                CreateNewProjectile();
+            }
+        }
+    }
+
+    void SelectExistingGunData(){
+        EditorGUILayout.LabelField("Gun Data:");
+        selectedGunData = EditorGUILayout.ObjectField(selectedGunData, typeof(GunData), false) as GunData;
+    }
+
+    void SetNewGunData(){
+        fireMode = (FireMode)EditorGUILayout.EnumPopup("Fire Mode: ", fireMode);
+        ammoCategory = (AmmoCategory)EditorGUILayout.EnumPopup("Ammo Type: ", ammoCategory);;
+        damage = EditorGUILayout.IntSlider("Damage: ", damage, 1, 1000);
+        magazineSize = EditorGUILayout.IntSlider("Magazine Size: ", magazineSize, 1, 100);
+        roundsPerMinute = EditorGUILayout.IntSlider("Rounds Per Minute: ", roundsPerMinute, 1, 500);
+        baseCritChance = EditorGUILayout.IntSlider("Base Crit Chance: ", baseCritChance, 0, 100);
+        baseCritMultiplier = EditorGUILayout.Slider("Base Crit Multiplier: ", baseCritMultiplier, 0, 3);
+        baseCritMultiplier = (float) System.Math.Round(baseCritMultiplier, 2);
+        baseStunChance = EditorGUILayout.IntSlider("Base Stun Chance: ", baseStunChance, 0, 100);
+    }
+
+    void InitializeGun(GameObject gun){
+        var gunScript = gun.AddComponent<Gun>();
+        
+        gunScript.InitializeGun(selectedGunData, isHitscan, selectedAbility);
+    }
+
+    #endregion
+
+    #region Projectile methods
+
+    void SelectExistingProjectile(){
+        EditorGUILayout.LabelField("Projectile:");
+        selectedExistingProjectile = EditorGUILayout.ObjectField(selectedExistingProjectile, typeof(GameObject), false) as GameObject;
+    }
+
+    void CreateNewProjectile(){
+        EditorGUILayout.LabelField("New Projectile Settings", EditorStyles.boldLabel);
+
+        EditorGUILayout.LabelField("Unique Projectile Name:");
+        projectileName = EditorGUILayout.TextField(projectileName);
+
+        EditorGUILayout.LabelField("Projectile Model:");
+        selectedProjectileModel =
+            EditorGUILayout.ObjectField(selectedProjectileModel, typeof(GameObject), false) as GameObject;
+        
+        EditorGUILayout.LabelField("Projectile Material:");
+        selectedProjectileMaterial = (Material) EditorGUILayout.ObjectField(selectedProjectileMaterial, typeof(Material), false);
+
+        if (!isHitscan){
+            projectileSpeed = EditorGUILayout.Slider("Projectile Speed: ", projectileSpeed, 1, 25);
+            projectileSpeed = (float) System.Math.Round(projectileSpeed, 2);
+            
+            maxProjectileTravel = EditorGUILayout.Slider("Max Projectile Distance: ", maxProjectileTravel, 1, 100);
+            maxProjectileTravel = (float) System.Math.Round(maxProjectileTravel, 2);
+        }
+        
+        if (isSticky = EditorGUILayout.Toggle("Can Stick?", isSticky)){
+            isBouncy = false;
+        }
+
+        if (isBouncy = EditorGUILayout.Toggle("Can Bounce?", isBouncy)){
+            isSticky = false;
+        }
+    }
+
+    void InitializeProjectile(GameObject projectile){
+        if (isHitscan){
+            projectile.AddComponent<ProjectileHitscanComponent>();
+        }
+        else{
+            var moveComponent = projectile.AddComponent<ProjectileMoveComponent>();
+            moveComponent.InitialiseProjectileMove(projectileSpeed, maxProjectileTravel);
+        }
+        if (isSticky){
+            projectile.AddComponent<ProjectileStickyCollisionComponent>();
+        }
+        else{
+            projectile.AddComponent<ProjectileStandardCollisionComponent>();
+        }
+
+        if (isBouncy){
+            projectile.AddComponent<ProjectileBounceComponent>();
+        }
+    }
+
+    #endregion
+
+    void BuildGunAndProjectile(){
+        using (new EditorGUI.DisabledScope((!CanUseExistingProjectile && !CanCreateNewProjectile) ||
+                                           !CanCreateNewGun)){
+            if (GUILayout.Button("Build Gun")){
+                // Create gun
+                if (createdGun != null) DestroyImmediate(createdGun);
+
+                createdGun = Instantiate(selectedGunModel, Vector3.zero, Quaternion.identity);
+                createdGun.name = gunName;
+
+                if (selectedGunMaterial != null){
+                    MeshRenderer[] childMeshes = createdGun.GetComponentsInChildren<MeshRenderer>();
+                    foreach (var child in childMeshes){
+                        child.material = selectedGunMaterial;
+                    }
+                }
+
+                if (useExistingGunData){
+                    InitializeGun(createdGun);
+                }
+                else{
+                    if (!useExistingProjectile){
+                        // Create projectile
+                        if (createdProjectile != null) DestroyImmediate(createdProjectile);
+
+                        createdProjectile = Instantiate(selectedProjectileModel, Vector3.zero, Quaternion.identity);
+                        createdProjectile.name = projectileName;
+
+                        if (selectedProjectileMaterial != null){
+                            createdProjectile.GetComponent<MeshRenderer>().material = selectedProjectileMaterial;
+                        }
+
+                        InitializeProjectile(createdProjectile);
+                        GameObject projectilePrefab = PrefabUtility.SaveAsPrefabAsset(createdProjectile, projectilePrefabPath + projectileName + ".prefab");
+
+                        CreateNewGunData(projectilePrefab);
+                        InitializeGun(createdGun);
+                        
+                        DestroyImmediate(createdProjectile);
+                    }
+                    else{
+                        CreateNewGunData(selectedExistingProjectile);
+                        InitializeGun(createdGun);
+                    }
+                    
+                    PrefabUtility.SaveAsPrefabAsset(createdGun, gunPrefabPath + gunName + ".prefab");
+                    DestroyImmediate(createdGun);
+                }
+            }
+        }
+    }
+
+    void CreateNewGunData(GameObject projectilePrefab){
+        GunData newGunData = ScriptableObject.CreateInstance(typeof(GunData)) as GunData;
+        
+        newGunData.InitialiseGunData(fireMode, ammoCategory, projectilePrefab, damage, magazineSize, roundsPerMinute, baseCritChance, baseCritMultiplier, baseStunChance);
+        
+        AssetDatabase.CreateAsset(newGunData, gunPrefabPath + gunName + "Data.asset");
+        AssetDatabase.SaveAssets();
+
+        selectedGunData = newGunData;
+    }
+}

--- a/Modular Weapon System/Assets/Scripts/Editor/GunCreationTool.cs.meta
+++ b/Modular Weapon System/Assets/Scripts/Editor/GunCreationTool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2aa19cc04d44874438f281b2d8f8e18e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Base Classes/GunAbility.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Base Classes/GunAbility.cs
@@ -1,0 +1,8 @@
+﻿using UnityEngine;
+
+public class GunAbility : ScriptableObject
+{
+    public virtual void Action(Gun gun, GunData gunData){
+        
+    }
+}

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Base Classes/GunAbility.cs.meta
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Base Classes/GunAbility.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8f2b2872f1842c845b414679392cb43a
+guid: 6f8e92ebd16654648866687c9394e97c
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Base Classes/GunAbilityComponent.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Base Classes/GunAbilityComponent.cs
@@ -1,9 +1,0 @@
-﻿using UnityEngine;
-
-[DisallowMultipleComponent]
-public abstract class GunAbilityComponent : GunComponent
-{
-    public override void Action(Gun gun, GunData gunData){
-        
-    }
-}

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Base Classes/GunData.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Base Classes/GunData.cs
@@ -48,4 +48,19 @@ public class GunData : ScriptableObject {
         critMultiplier = new ModifiableAttribute<float>(baseCritMultiplier);
         stunChance = new ModifiableAttribute<int>(baseStunChance);
     }
+
+    /**
+     * used to initialise new GunData assets created within the gun creator tool
+     */
+    public void InitialiseGunData(FireMode fireMode, AmmoCategory ammoCategory, GameObject projectilePrefab, int damage, int magazineSize, int roundsPerMinute, int baseCritChance, float baseCritMultiplier, int baseStunChance){
+        this.fireMode = fireMode;
+        this.ammoCategory = ammoCategory;
+        this.projectilePrefab = projectilePrefab;
+        this.damage = damage;
+        this.magazineSize = magazineSize;
+        this.roundsPerMinute = roundsPerMinute;
+        this.baseCritChance = baseCritChance;
+        this.baseCritMultiplier = baseCritMultiplier;
+        this.baseStunChance = baseStunChance;
+    }
 }

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Abilities.meta
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Abilities.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d18f60e3f2572fd4aae63616f131a25f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Abilities/BlankGunAbility.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Abilities/BlankGunAbility.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "New Blank Gun Ability", menuName = "Gun Abilities/Blank Gun Ability")]
+public class BlankGunAbility : GunAbility
+{
+    public override void Action(Gun gun, GunData gunData){
+        Debug.Log("Ability used");
+    }
+}

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Abilities/BlankGunAbility.cs.meta
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Abilities/BlankGunAbility.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 17fdbb4d2b8f7d74ba46d55e65246383
+guid: 8d7e4579aea10384a85c69b3c31fe114
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/CritChanceMod.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/CritChanceMod.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-[CreateAssetMenu(fileName = "New Crit Chance Modifier", menuName = "Gun Mods/Generic/CritChanceModifier")]
+[CreateAssetMenu(fileName = "New Crit Chance Modifier", menuName = "Gun Mods/Generic/Crit Chance Modifier")]
 public class CritChanceMod : GunModifier
 {
     [Tooltip("Crit chance as a percentage in value form before modifiers.")]

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/CritMultiplierMod.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/CritMultiplierMod.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-[CreateAssetMenu(fileName = "New Crit Multiplier", menuName = "Gun Mods/Generic/CritMultiplier")]
+[CreateAssetMenu(fileName = "New Crit Multiplier", menuName = "Gun Mods/Generic/Crit Multiplier")]
 public class CritMultiplierMod : GunModifier
 {
     [Tooltip("Crit multiplier as a percentage in decimal form before modifiers.")]

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/GuaranteedCritAfterReloadMod.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/GuaranteedCritAfterReloadMod.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-[CreateAssetMenu(fileName = "New Guaranteed Crit After Reload", menuName = "Gun Mods/GuaranteedCritAfterReload")]
+[CreateAssetMenu(fileName = "New Guaranteed Crit After Reload", menuName = "Gun Mods/Guaranteed Crit After Reload")]
 public class GuaranteedCritAfterReloadMod : GunModifier
 {
     int bulletCount;

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/GunDamageMultiplierMod.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/GunDamageMultiplierMod.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-[CreateAssetMenu(fileName = "New Gun Damage Multiplier", menuName = "Gun Mods/Generic/GunDamageMultiplier")]
+[CreateAssetMenu(fileName = "New Gun Damage Multiplier", menuName = "Gun Mods/Generic/Gun Damage Multiplier")]
 public class GunDamageMultiplierMod : GunModifier
 {
     [Tooltip("Damage multiplier as a percentage in decimal form before modifiers.")]

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/IncreaseDamageAfterReloadMod.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/IncreaseDamageAfterReloadMod.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-[CreateAssetMenu(fileName = "New Increase Damage After Reload", menuName = "Gun Mods/IncreaseDamageAfterReload")]
+[CreateAssetMenu(fileName = "New Increase Damage After Reload", menuName = "Gun Mods/Increase Damage After Reload")]
 public class IncreaseDamageAfterReloadMod : GunModifier
 {
     float elapsedTime;

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/MagazineSizeMod.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/MagazineSizeMod.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-[CreateAssetMenu(fileName = "New Magazine Size Multiplier", menuName = "Gun Mods/Generic/MagazineSizeMultiplier")]
+[CreateAssetMenu(fileName = "New Magazine Size Multiplier", menuName = "Gun Mods/Generic/Magazine Size Multiplier")]
 public class MagazineSizeMod : GunModifier
 {
     [Tooltip("Magazine size multiplier as a percentage in decimal form before modifiers.")]

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/ReloadOnUnequipMod.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/ReloadOnUnequipMod.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-[CreateAssetMenu(fileName = "New Reload On Unequip Modifier", menuName = "Gun Mods/ReloadOnUnequip")]
+[CreateAssetMenu(fileName = "New Reload On Unequip Modifier", menuName = "Gun Mods/Reload On Unequip")]
 public class ReloadOnUnequipMod : GunModifier
 {
     float elapsedTime;

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/ReloadTimeMultiplierMod.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/ReloadTimeMultiplierMod.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-[CreateAssetMenu(fileName = "New Reload Time Multiplier", menuName = "Gun Mods/Generic/ReloadTimeMultiplier")]
+[CreateAssetMenu(fileName = "New Reload Time Multiplier", menuName = "Gun Mods/Generic/Reload Time Multiplier")]
 public class ReloadTimeMultiplierMod : GunModifier
 {
     [Tooltip("Reload Time multiplier as a percentage in decimal form before modifiers.")]

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/RoundsPerMinuteMultiplierMod.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/RoundsPerMinuteMultiplierMod.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-[CreateAssetMenu(fileName = "New Rounds Per Minute Multiplier", menuName = "Gun Mods/Generic/RoundsPerMinuteMultiplier")]
+[CreateAssetMenu(fileName = "New Rounds Per Minute Multiplier", menuName = "Gun Mods/Generic/Rounds Per Minute Multiplier")]
 public class RoundsPerMinuteMultiplierMod : GunModifier
 {
     [Tooltip("Rounds per minute multiplier as a percentage in decimal form before modifiers.")]

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/StunChanceMod.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/StunChanceMod.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-[CreateAssetMenu(fileName = "New Stun Chance Modifier", menuName = "Gun Mods/Generic/StunChanceModifier")]
+[CreateAssetMenu(fileName = "New Stun Chance Modifier", menuName = "Gun Mods/Generic/Stun Chance Modifier")]
 public class StunChanceMod : GunModifier
 {
     [Tooltip("Crit chance as a percentage in value form before modifiers.")]

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun.cs
@@ -73,20 +73,20 @@ public class Gun : MonoBehaviour, IEquippable, IModdable<GunModifier>
             fireComponent.Action(this, gunData);
         }
     }
-
-    public void Ability(){
-        if (reloadComponent.IsReloading()) return;
-        if (ability == null) return;
-        
-        ability.Action(this, gunData);
-    }
-
+    
     public void Reload(){
         int magazineSizeAdjusted = (int)Mathf.Ceil(gunData.MagazineSize * gunData.MagazineSizeMultiplier.Value);
         
         if (bulletsInMagazine < magazineSizeAdjusted){
             reloadComponent.Action(this, gunData);
         }
+    }
+
+    public void Ability(){
+        if (reloadComponent.IsReloading()) return;
+        if (ability == null) return;
+        
+        ability.Action(this, gunData);
     }
 
     public void IncreaseMagazine(int amount){

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun.cs
@@ -25,7 +25,9 @@ public class Gun : MonoBehaviour, IEquippable, IModdable<GunModifier>
     [Header("Gun Components")]
     [SerializeField] GunFireComponent fireComponent; public GunFireComponent FireComponent => fireComponent;
     [SerializeField] GunReloadComponent reloadComponent; public GunReloadComponent ReloadComponent => reloadComponent;
-    [SerializeField] GunAbilityComponent abilityComponent; public GunAbilityComponent AbilityComponent => abilityComponent;
+    
+    [Header("Gun Ability")]
+    [SerializeField] GunAbility ability;
 
     [Header("Gun Object Settings")]
     [Tooltip("Assign a GameObject to represent the gun muzzle position of the gun model.")]
@@ -74,7 +76,7 @@ public class Gun : MonoBehaviour, IEquippable, IModdable<GunModifier>
     public void Ability(){
         if (reloadComponent.IsReloading()) return;
         
-        abilityComponent.Action(this, gunData);
+        ability.Action(this, gunData);
     }
 
     public void Reload(){
@@ -103,6 +105,20 @@ public class Gun : MonoBehaviour, IEquippable, IModdable<GunModifier>
     public void RemoveMod(GunModifier mod){
         mods.Remove(mod);
         mod.RemoveFrom(this);
+    }
+
+    public void SetupGun(GunData gunData, GunAbility ability){
+        InitializeGunData(gunData);
+        InitializeGunComponents();
+        this.ability = ability;
+    }
+    
+    void InitializeGunData(GunData gunData){
+        this.gunData = gunData;
+    }
+    void InitializeGunComponents(){
+        fireComponent = GetComponent<GunFireComponent>();
+        reloadComponent = GetComponent<GunReloadComponent>();
     }
     
     void InitializeAttachedMods(){

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun.cs
@@ -6,11 +6,12 @@ public delegate void OnGunAction(Gun target);
 [DisallowMultipleComponent][RequireComponent(typeof(Animator))]
 public class Gun : MonoBehaviour, IEquippable, IModdable<GunModifier>
 {
+    Animator animator;
+    
 // Remove value is never used warning from inspector
 #pragma warning disable 0649
-    Animator animator;
     [Header("Type of Gun")]
-    [SerializeField] private GunType gunType; public GunType GunType => gunType;
+    [SerializeField] private GunType gunType = GunType.Projectile; public GunType GunType => gunType;
     
     [Header("Player Ammo Storage Script")]
     [SerializeField] private AmmoStorage playerAmmoStorage; public AmmoStorage PlayerAmmoStorage => playerAmmoStorage;
@@ -75,6 +76,7 @@ public class Gun : MonoBehaviour, IEquippable, IModdable<GunModifier>
 
     public void Ability(){
         if (reloadComponent.IsReloading()) return;
+        if (ability == null) return;
         
         ability.Action(this, gunData);
     }
@@ -94,6 +96,29 @@ public class Gun : MonoBehaviour, IEquippable, IModdable<GunModifier>
     public void DecrementMagazine(){
         bulletsInMagazine--;
     }
+    
+    /**
+     * used to initialise new gun prefabs created within the gun creator tool
+     */
+    public void InitializeGun(GunData gunData, bool isHitscan, GunAbility ability){
+        InitializeGunComponents();
+        this.gunData = gunData;
+        
+        if (isHitscan){
+            gunType = GunType.Hitscan;
+        }
+        
+        if (ability == null) return;
+        this.ability = ability;
+    }
+    
+    /**
+     * used to initialise new gun prefabs created within the gun creator tool
+     */
+    void InitializeGunComponents(){
+        fireComponent = GetComponent<GunFireComponent>();
+        reloadComponent = GetComponent<GunReloadComponent>();
+    }
 
     public void AddMod(GunModifier mod){
         if (mods.Contains(mod)) return;
@@ -107,20 +132,6 @@ public class Gun : MonoBehaviour, IEquippable, IModdable<GunModifier>
         mod.RemoveFrom(this);
     }
 
-    public void SetupGun(GunData gunData, GunAbility ability){
-        InitializeGunData(gunData);
-        InitializeGunComponents();
-        this.ability = ability;
-    }
-    
-    void InitializeGunData(GunData gunData){
-        this.gunData = gunData;
-    }
-    void InitializeGunComponents(){
-        fireComponent = GetComponent<GunFireComponent>();
-        reloadComponent = GetComponent<GunReloadComponent>();
-    }
-    
     void InitializeAttachedMods(){
         if(mods == null) { 
             mods = new List<GunModifier>(); 

--- a/Modular Weapon System/Assets/Scripts/Entities/Projectiles/ProjectileMoveComponent.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Projectiles/ProjectileMoveComponent.cs
@@ -38,4 +38,9 @@ public class ProjectileMoveComponent : ProjectileComponent
         // faster than Vector3.Distance and Mathf.Sqrt
         return (startPosition - transform.position).sqrMagnitude > maxDistance * maxDistance;
     }
+
+    public void InitialiseProjectileMove(float projectileSpeed, float maxProjectileTravel){
+        this.projectileSpeed = projectileSpeed;
+        this.maxProjectileTravel = maxProjectileTravel;
+    }
 }

--- a/Modular Weapon System/Assets/Scripts/Player/Player.cs
+++ b/Modular Weapon System/Assets/Scripts/Player/Player.cs
@@ -36,6 +36,10 @@ public class Player : MonoBehaviour
         if (Input.GetMouseButtonUp(0)){
             fireHeld = false;
         }
+        
+        if (Input.GetMouseButtonDown(1)){
+            heldGun.Ability();
+        }
 
         if (Input.GetKeyDown(KeyCode.R)){
             heldGun.Reload();


### PR DESCRIPTION
Custom editor created for automatically gun building, tool is capable of building guns on the fly and adding all the necessary components based on the settings chosen.

Editor provides support for both new and existing projectile use.

Internal preview implemented and objects are also temporarily instantiated in the scene for a complete overview.

Initialisation methods added to Gun.cs, GunData.cs and ProjectileMove.cs, these methods are required for the custom editor to provide the correct values to each component at creation.



