### PR TITLE
Add bullet spread modifier support and fix edge cases

### DIFF
--- a/Modular Weapon System/Assets/Scripts/Editor/GunCreationTool.cs
+++ b/Modular Weapon System/Assets/Scripts/Editor/GunCreationTool.cs
@@ -27,7 +27,7 @@ public class GunCreationTool : EditorWindow
     int damage;
     int magazineSize;
     int roundsPerMinute;
-    float spreadRadius;
+    float baseSpreadRadius;
     int baseCritChance;
     float baseCritMultiplier;
     int baseStunChance;
@@ -224,8 +224,8 @@ public class GunCreationTool : EditorWindow
         damage = EditorGUILayout.IntSlider("Damage: ", damage, 1, 1000);
         magazineSize = EditorGUILayout.IntSlider("Magazine Size: ", magazineSize, 1, 100);
         roundsPerMinute = EditorGUILayout.IntSlider("Rounds Per Minute: ", roundsPerMinute, 1, 500);
-        spreadRadius = EditorGUILayout.Slider("Spread Radius: ", spreadRadius, 0, 10);
-        spreadRadius = (float) System.Math.Round(spreadRadius, 2);
+        baseSpreadRadius = EditorGUILayout.Slider("Spread Radius: ", baseSpreadRadius, 0, 10);
+        baseSpreadRadius = (float) System.Math.Round(baseSpreadRadius, 2);
         baseCritChance = EditorGUILayout.IntSlider("Base Crit Chance: ", baseCritChance, 0, 100);
         baseCritMultiplier = EditorGUILayout.Slider("Base Crit Multiplier: ", baseCritMultiplier, 0, 3);
         baseCritMultiplier = (float) System.Math.Round(baseCritMultiplier, 2);
@@ -370,7 +370,7 @@ public class GunCreationTool : EditorWindow
     void CreateNewGunData(GameObject projectilePrefab){
         GunData newGunData = CreateInstance(typeof(GunData)) as GunData;
         
-        newGunData.InitialiseGunData(fireMode, ammoCategory, projectilePrefab, damage, magazineSize, roundsPerMinute, spreadRadius, baseCritChance, baseCritMultiplier, baseStunChance);
+        newGunData.InitialiseGunData(fireMode, ammoCategory, projectilePrefab, damage, magazineSize, roundsPerMinute, baseSpreadRadius, baseCritChance, baseCritMultiplier, baseStunChance);
         
         AssetDatabase.CreateAsset(newGunData, gunPrefabPath + gunName + "Data.asset");
         AssetDatabase.SaveAssets();

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Base Classes/GunData.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Base Classes/GunData.cs
@@ -19,8 +19,8 @@ public class GunData : ScriptableObject {
     [Tooltip("Guns RPM as a value before modifiers.")]
     [SerializeField][MinAttribute(1)] int roundsPerMinute; public int RoundsPerMinute => roundsPerMinute;
     
-    [Tooltip("The random deviation of bullets within a set radius")]
-    [SerializeField][MinAttribute(0)] float spreadRadius = 0; public float SpreadRadius => spreadRadius;
+    [Tooltip("The random deviation of bullets within a set radius before modifiers")]
+    [SerializeField][MinAttribute(0)] float baseSpreadRadius = 0; 
 
     [Tooltip("Guns crit chance as a percentage before modifiers.")]
     [SerializeField][MinAttribute(0)] int baseCritChance;
@@ -39,6 +39,7 @@ public class GunData : ScriptableObject {
     ModifiableAttribute<float> reloadTimeMultiplier; public ModifiableAttribute<float> ReloadTimeMultiplier => reloadTimeMultiplier;
     ModifiableAttribute<float> critMultiplier; public ModifiableAttribute<float> CritMultiplier => critMultiplier;
     ModifiableAttribute<float> roundsPerMinuteMultiplier; public ModifiableAttribute<float> RoundsPerMinuteMultiplier => roundsPerMinuteMultiplier;
+    ModifiableAttribute<float> spreadRadiusModified; public ModifiableAttribute<float> SpreadRadius => spreadRadiusModified;
     ModifiableAttribute<int> critChance; public ModifiableAttribute<int> CritChance => critChance;
     ModifiableAttribute<int> stunChance; public ModifiableAttribute<int> StunChance => stunChance;
 
@@ -48,6 +49,7 @@ public class GunData : ScriptableObject {
         magazineSizeMultiplier = new ModifiableAttribute<float>(1f);
         reloadTimeMultiplier = new ModifiableAttribute<float>(1f);
         roundsPerMinuteMultiplier = new ModifiableAttribute<float>(1f);
+        spreadRadiusModified = new ModifiableAttribute<float>(baseSpreadRadius);
         critChance = new ModifiableAttribute<int>(baseCritChance);
         critMultiplier = new ModifiableAttribute<float>(baseCritMultiplier);
         stunChance = new ModifiableAttribute<int>(baseStunChance);
@@ -56,14 +58,14 @@ public class GunData : ScriptableObject {
     /**
      * used to initialise new GunData assets created within the gun creator tool
      */
-    public void InitialiseGunData(FireMode fireMode, AmmoCategory ammoCategory, GameObject projectilePrefab, int damage, int magazineSize, int roundsPerMinute, float spreadRadius, int baseCritChance, float baseCritMultiplier, int baseStunChance){
+    public void InitialiseGunData(FireMode fireMode, AmmoCategory ammoCategory, GameObject projectilePrefab, int damage, int magazineSize, int roundsPerMinute, float baseSpreadRadius, int baseCritChance, float baseCritMultiplier, int baseStunChance){
         this.fireMode = fireMode;
         this.ammoCategory = ammoCategory;
         this.projectilePrefab = projectilePrefab;
         this.damage = damage;
         this.magazineSize = magazineSize;
         this.roundsPerMinute = roundsPerMinute;
-        this.spreadRadius = spreadRadius;
+        this.baseSpreadRadius = baseSpreadRadius;
         this.baseCritChance = baseCritChance;
         this.baseCritMultiplier = baseCritMultiplier;
         this.baseStunChance = baseStunChance;

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Components/GunFireComponent.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Components/GunFireComponent.cs
@@ -25,13 +25,16 @@ public class GunFireComponent : GunComponent
 
         Vector3 muzzlePosition = gun.GunMuzzlePosition.transform.position;
         GameObject projectile = Instantiate(gunData.ProjectilePrefab, muzzlePosition, Quaternion.identity);
-
+        
+        // ensure spread is not a negative value
+        float spreadRadius = Mathf.Max(0, gunData.SpreadRadius.Value);
+        
         switch (gun.GunType){
             case GunType.Projectile:
-                ProjectileMoveTypeHandler(muzzlePosition, gunData.SpreadRadius, projectile);
+                ProjectileMoveTypeHandler(muzzlePosition, spreadRadius, projectile);
                 break;
             case GunType.Hitscan:
-                ProjectileHitscanTypeHandler(gunData.SpreadRadius, projectile);
+                ProjectileHitscanTypeHandler(spreadRadius, projectile);
                 break;
         }
         
@@ -64,13 +67,16 @@ public class GunFireComponent : GunComponent
 
     void ProjectileHitscanTypeHandler(float spreadRadius, GameObject projectile){
         ProjectileHitscanComponent projectileHitscan = projectile.GetComponent<ProjectileHitscanComponent>();
-        projectileHitscan.InitialiseHitscan(GetProjectileDir(spreadRadius, 999f));
+        float maxHitscanDistance = projectileHitscan.MaxHitscanDistance;
+        projectileHitscan.InitialiseHitscan(GetProjectileDir(spreadRadius, maxHitscanDistance));
     }
     
     void ProjectileDamageComponentHandler(GunData gunData, GameObject projectile){
         ProjectileDamageComponent projectileDamageComponent = projectile.GetComponent<ProjectileDamageComponent>();
         
-        float damage = gunData.Damage * gunData.DamageMultiplier.Value;
+        // ensure damage is always 0 or greater to avoid edge cases when applying damage to enemies
+        float damage = Mathf.Max(0,gunData.Damage * gunData.DamageMultiplier.Value); 
+        
         bool isCrit = IsCrit(gunData);
         projectileDamageComponent.ProjectileDamage = (isCrit ? gunData.CritMultiplier.Value : 1) * damage;
     }

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Components/GunReloadComponent.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Components/GunReloadComponent.cs
@@ -28,7 +28,7 @@ public class GunReloadComponent : GunComponent
 
         if (availableAmmo > 0){
             float reloadMultiplier = gunData.ReloadTimeMultiplier.Value;
-            float reloadTimeAdjusted = this.reloadTime / reloadMultiplier;
+            float reloadTimeAdjusted = reloadTime / reloadMultiplier;
 
             animator.SetFloat("reloadTimeMultiplier", reloadMultiplier);
 
@@ -42,8 +42,10 @@ public class GunReloadComponent : GunComponent
         animator.SetTrigger("IsReload");
         yield return new WaitForSeconds(reloadTime); // do not reload gun until it has been completed
 
+        // round magazine size to highest int and ensure magazine can hold at least 1 bullet after modifiers
         int magazineSizeAdjusted = (int)Mathf.Ceil(gunData.MagazineSize * gunData.MagazineSizeMultiplier.Value);
-
+        magazineSizeAdjusted = Mathf.Max(1, magazineSizeAdjusted);
+        
         int maximumReloadAmount = Mathf.Min(availableAmmo, magazineSizeAdjusted - gun.BulletsInMagazine); // maximum amount should never exceed magazine size
         gun.IncreaseMagazine(maximumReloadAmount);
         gun.PlayerAmmoStorage.ReduceAmmoAmount(category, maximumReloadAmount);

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/BulletSpreadMod.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/BulletSpreadMod.cs
@@ -1,0 +1,21 @@
+﻿using UnityEngine;
+
+[CreateAssetMenu(fileName = "New Bullet Spread Modifier", menuName = "Gun Mods/Generic/Bullet Spread Modifier")]
+public class BulletSpreadMod : GunModifier
+{
+    [Tooltip("Bullet spread adjustment as a value before additional modifiers.")]
+    [SerializeField] int bulletSpreadValue;
+
+    float BulletSpreadRadius(float currentValue){
+        return currentValue + bulletSpreadValue;
+    }
+
+    public override void ApplyTo(Gun target){
+        target.GunData.SpreadRadius.AddMod(this.GetInstanceID(), BulletSpreadRadius);
+    }
+
+    public override void RemoveFrom(Gun target){
+        target.GunData.CritChance.RemoveMod(this.GetInstanceID());
+    }
+}
+

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/BulletSpreadMod.cs.meta
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/BulletSpreadMod.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca17689789b23734eaa51f985772a7e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/GunRecoilMod.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun Modifiers/GunRecoilMod.cs
@@ -16,19 +16,19 @@ public class GunRecoilMod : GunModifier
     [Tooltip("Should gun reset transform back to original position after delay period.")]
     [SerializeField] bool canResetTransform = false;
     [Tooltip("Wait time before transform resets back to original rotation after player stops shooting.")]
-    [SerializeField] float transformResetDelay;
+    [SerializeField][MinAttribute(0)] float transformResetDelay;
     [Tooltip("Total time in seconds taken to reset gun from current rotation to its original rotation.")]
-    [SerializeField] float transformResetDuration;
+    [SerializeField][MinAttribute(0)] float transformResetDuration;
     float elapsedTimeSinceShot;
     float elapsedTimeSinceResetStart;
 
     [Header("Recoil Settings")]
     [Tooltip("Horizontal recoil amount in degrees.")]
-    [SerializeField] float horizontalRecoilAmount;
+    [SerializeField][MinAttribute(0)] float horizontalRecoilAmount;
     [Tooltip("Vertical recoil amount in degrees.")]
-    [SerializeField] float verticalRecoilAmount;
+    [SerializeField][MinAttribute(0)] float verticalRecoilAmount;
     [Tooltip("How quick the gun goes from current rotation to target rotation after shooting.")]
-    [SerializeField] float recoilSpeed;
+    [SerializeField][MinAttribute(0)] float recoilSpeed;
 
     void CalculateRecoil(Gun target){
         elapsedTimeSinceShot = 0;
@@ -72,8 +72,7 @@ public class GunRecoilMod : GunModifier
         originalRotation = gunHolderTransform.rotation;
         currentRotation = originalRotation;
         elapsedTimeSinceShot = transformResetDelay;
-        
-        
+
         target.FireComponent.onFire += CalculateRecoil;
         target.onUpdate += OnUpdate;
     }

--- a/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Guns/Gun.cs
@@ -100,7 +100,7 @@ public class Gun : MonoBehaviour, IEquippable, IModdable<GunModifier>
     public void EnableCrosshair(GameObject crosshair){
         crosshair.SetActive(true);
         RectTransform[] children = crosshair.GetComponentsInChildren<RectTransform>();
-        float crosshairSpreadRadius = gunData.SpreadRadius;
+        float crosshairSpreadRadius = gunData.SpreadRadius.Value;
 
         // 0 is parent and 1 is center that should not be offset
         for (int i = 2; i < children.Length; i++){

--- a/Modular Weapon System/Assets/Scripts/Entities/Projectiles/ProjectileHitscanComponent.cs
+++ b/Modular Weapon System/Assets/Scripts/Entities/Projectiles/ProjectileHitscanComponent.cs
@@ -3,6 +3,9 @@
 [DisallowMultipleComponent]
 public class ProjectileHitscanComponent : ProjectileComponent
 {
+    [Range(1, 100)]
+    [SerializeField] float maxHitscanDistance = default; public float MaxHitscanDistance => maxHitscanDistance;
+    
     public void InitialiseHitscan(Vector3 pointOfImpact){
         transform.position = pointOfImpact;
     }


### PR DESCRIPTION
Bullet spread modifier support has been added.

New generic bullet spread mod has been created.

Mathf.Max used when getting values of non percentage based modifiable attributes to ensure returned value is not below the minimum threshold for that stat type.